### PR TITLE
Set STATUS mode for CMake message() function calls

### DIFF
--- a/cmake/GitUtils.cmake
+++ b/cmake/GitUtils.cmake
@@ -128,7 +128,7 @@ function(git_clone)
     endif()
 
     if(NOT PARGS_QUIET)
-        message("${git_output}")
+        message(STATUS "${git_output}")
     endif()
 
     # now checkout the right commit
@@ -152,6 +152,6 @@ function(git_clone)
     endif()
 
     if(NOT PARGS_QUIET)
-        message("${git_output}")
+        message(STATUS "${git_output}")
     endif()
 endfunction()


### PR DESCRIPTION
Not having a mode causes the message to print to stderr instead of stdout.

There are some setups where anything printed to stderr is considered an error for the purposes of determining if a subprocess worked or not. I recently encountered this problem where messages getting printed to stderr by CMake were causing commands to terminate (on CI builds) -- it seemed to be most problematic when using powershell to run a setuptools build (that compiles a native module using CMake).